### PR TITLE
Prevents GLOBAL ReferenceError in hot browsers

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -249,7 +249,7 @@ Server.prototype = {
       webpackConfig.plugins = webpackConfig.plugins || [];
       webpackConfig.plugins.unshift(
         new webpack.BannerPlugin(
-          'if (GLOBAL && GLOBAL.document) {\n' +
+          'if (typeof(GLOBAL) !== \'undefined\' && GLOBAL.document) {\n' +
           '  document.createElement = function() {\n' +
           '    return HTMLDocument.prototype.createElement.apply(document, arguments);\n' +
           '  };\n' +


### PR DESCRIPTION
Let's say you're running with the `--hot` switch on, and your webpack config looks like this:

``` js
entry: {
  'index.ios': ['./src/ios'],
  'index.web': ['./src/web'],
}
```

_... Where your browser loads the `index.web` bundle directly from the webpackDevServer instance, and you want to use `react-hot-loader` there, too._

This avoids the ReferenceError thrown when a browser encounters `GLOBAL` within the banner injected to shim document.createElement for react-native.
