### PR TITLE
Transform static image references into externals

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -215,11 +215,24 @@ Server.prototype = {
     var reactNativePath = path.resolve(process.cwd(), 'node_modules/react-native');
     var reactNativeExternals = getReactNativeExternals(path.join(reactNativePath, 'Libraries'));
 
+    // Coerce externals into an array, without clobbering it
+    webpackConfig.externals = Array.isArray(webpackConfig.externals)
+      ? webpackConfig.externals
+      : [(webpackConfig.externals || {})];
+
     // Inject react native externals
-    webpackConfig.externals = webpackConfig.externals || {};
-    for (var mod in reactNativeExternals) {
-      webpackConfig.externals[mod] = reactNativeExternals[mod];
-    }
+    webpackConfig.externals.push(reactNativeExternals);
+    
+    // Transform static image references 
+    webpackConfig.externals.push(function(context, request, callback) {
+      if (/^image!/.test(request)) {
+        return callback(null, JSON.stringify({
+          uri: request.replace('image!', ''),
+          isStatic: true
+        }));
+      }
+      callback();
+    });
 
     // By default webpack uses webpack://[resource-path]?[hash] in the source
     // map which is handled by its dev server. Use absolute path instead so


### PR DESCRIPTION
When left intact, react-native's static image references, e.g. `require('image!fooBar')`, are problematic. By default, webpack attempts to resolve a loader called webpack-image-loader (plus many derivative names) and to resolve a module ('fooBar') based on the string after the bang. This yields compile errors, in my experience.

So, seems these references need to be short-circuited. This PR does that by generating corresponding externals:

``` js
require('image!fooBar')

// yields
{ uri: 'fooBar', isStatic: true }
```

I believe this resolves #6 assuming @boyswan and I were seeing the same thing.
