### PR TITLE
Move the code to require the webpack config file to the cli parser

### DIFF
--- a/bin/react-native-webpack-server.js
+++ b/bin/react-native-webpack-server.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+var path = require('path');
+var fs = require('fs');
 var parser = require('nomnom');
 var Server = require('../lib/Server');
 
@@ -27,6 +29,15 @@ parser.command('start')
     default: false,
   })
   .callback(function(opts) {
+    opts.webpackConfigPath = path.resolve(process.cwd(), opts.webpackConfigPath);
+    if (fs.existsSync(opts.webpackConfigPath)) {
+      opts.webpackConfig = require(path.resolve(process.cwd(), opts.webpackConfigPath));
+    } else {
+      throw new Error('Must specify webpackConfigPath or create ./webpack.config.js');
+-     process.exit(1);
+    }
+    delete opts.webpackConfigPath;
+
     (new Server(opts)).start();
   });
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -43,7 +43,7 @@ function fetch(uri) {
  * {Number} packagerPort (default 8081)
  * {Number} webpackPort (default 8082)
  * {String} entry (default index.ios)
- * {String} webpackConfigPath (default ./webpack.config.js)
+ * {Object} webpackConfig (default require(./webpack.config.js))
  * {Boolean} hot enable react-hot-loader (default false)
  *
  * @constructor
@@ -59,14 +59,7 @@ function Server(options) {
   this.webpackPort = options.webpackPort || 8082;
   this.entry = options.entry || 'index.ios';
   this.hot = (options.hot === true);
-  this.webpackConfigPath = options.webpackConfigPath || 'webpack.config.js';
-  this.webpackConfigPath = path.resolve(process.cwd(), this.webpackConfigPath);
-
-  // Check for webpack config.
-  if (!fs.existsSync(this.webpackConfigPath)) {
-    throw new Error('Must specify webpackConfigPath or create ./webpack.config.js');
-    process.exit(1);
-  }
+  this.webpackConfig = options.webpackConfig;
 
   // Check for local react-native.
   if (!fs.existsSync(path.resolve(process.cwd(), 'node_modules/react-native'))) {
@@ -208,7 +201,7 @@ Server.prototype = {
   },
 
   _startWebpackDevServer: function() {
-    var webpackConfig = require(this.webpackConfigPath);
+    var webpackConfig = this.webpackConfig;
     var webpackURL = 'http://' + this.hostname + ':' + this.webpackPort;
     var hot = this.hot;
     var publicPath = hot ? (webpackURL + '/') : null;


### PR DESCRIPTION
This fixes issue #8 by moving the code to require the
webpack config file from lib/Server.js to the cli parser.
This way the cli option (webpackConfigPath) stays the same but
lib/Server.js can now be used by passing a webpack config object
instead of a webpack config file path.
