### PR TITLE
Replace react-native peerDependency with version check, fix #47

### DIFF
--- a/bin/react-native-webpack-server.js
+++ b/bin/react-native-webpack-server.js
@@ -34,7 +34,7 @@ parser.command('start')
       opts.webpackConfig = require(path.resolve(process.cwd(), opts.webpackConfigPath));
     } else {
       throw new Error('Must specify webpackConfigPath or create ./webpack.config.js');
--     process.exit(1);
+      process.exit(1);
     }
     delete opts.webpackConfigPath;
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1,5 +1,11 @@
 'use strict';
 
+var INVALID_VERSIONS = ['0.5.0']
+var RNInfo = require('react-native/package.json')
+if (INVALID_VERSIONS.indexOf(RNInfo.version) !== -1) {
+  throw new Error('react-native-webpack-server does not work with react-native version: ' + RNInfo.version)
+}
+
 var fs = require('fs');
 var path = require('path');
 var http = require('http');

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   ],
   "peerDependencies": {
     "react-hot-loader": ">=1.2.4",
-    "react-native": ">=0.4.3 <0.5.0 || 0.6.0-rc || >=0.6.0 || 0.8.0-rc.2",
     "webpack": ">=1.8.4",
     "webpack-dev-server": ">=1.8.0"
   },
@@ -39,5 +38,8 @@
     "connect": "^3.3.5",
     "source-map": "^0.4.2",
     "nomnom": "^1.8.1"
+  },
+  "devDependencies": {
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
The semver range needs to be bumped each time a new rc version is released, and the peerDependency does not auto install in npm@3.x.

So, instead of using `peerDependencies`, a check has been added against the current version, so we can throw a useful error if a known incompatible version of react-native is being used (as was needed for #33)
