### PR TITLE
Update to support new module API

### DIFF
--- a/lib/getReactNativeExternals.js
+++ b/lib/getReactNativeExternals.js
@@ -21,11 +21,15 @@ function getReactNativeExternals() {
     transformModulePath: require.resolve('react-native/packager/transformer')
   }, reactNativePackage.main).then(function(dependencies) {
     return dependencies.filter(function(dependency) {
-      return !dependency.isPolyfill;
+      return !dependency.isPolyfill();
     });
   }).then(function(dependencies) {
-    return dependencies.reduce(function(externals, dependency) {
-      externals[dependency.id] = 'commonjs ' + dependency.id;
+    return Promise.all(dependencies.map(function(dependency) {
+      return dependency.getName();
+    }));
+  }).then(function(moduleIds) {
+    return moduleIds.reduce(function(externals, moduleId) {
+      externals[moduleId] = 'commonjs ' + moduleId
       return externals;
     }, {});
   });


### PR DESCRIPTION
https://github.com/facebook/react-native/commit/bc28a35bda0e358a8296a7b53eb7315b736c6e4b
- modules are no longer plain objects
- `isPolyfill` is now a function
- `id` is now retrieved asynchronously with `getName`
