### PR TITLE
Explicitly depend on react-native-webpack-server in example projects

### DIFF
--- a/Examples/BabelES6/package.json
+++ b/Examples/BabelES6/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "node ../../bin/react-native-webpack-server start",
-    "hot": "HOT=1 node ../../bin/react-native-webpack-server start --hot"
+    "start": "react-native-webpack-server start",
+    "hot": "HOT=1 react-native-webpack-server start --hot"
   },
   "dependencies": {
     "babel": "^5.1.4",
@@ -12,7 +12,8 @@
     "babel-loader": "^5.0.0",
     "react": "^0.13.1",
     "react-hot-loader": "^1.2.4",
-    "react-native": ">=0.4.3",
+    "react-native": "^0.9.0",
+    "react-native-webpack-server": "^0.3.0",
     "webpack": "^1.8.4",
     "webpack-dev-server": "^1.8.0"
   }

--- a/Examples/BabelES6/webpack.config.js
+++ b/Examples/BabelES6/webpack.config.js
@@ -30,7 +30,7 @@ var config = {
 // Hot loader
 if (process.env.HOT) {
   config.devtool = 'eval'; // Speed up incremental builds
-  config.entry['index.ios'].unshift('../../hot/entry');
+  config.entry['index.ios'].unshift('react-native-webpack-server/hot/entry');
   config.entry['index.ios'].unshift('webpack/hot/only-dev-server');
   config.entry['index.ios'].unshift('webpack-dev-server/client?http://localhost:8082');
   config.output.publicPath = 'http://localhost:8082/';

--- a/Examples/CoffeeScript/package.json
+++ b/Examples/CoffeeScript/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "node ../../bin/react-native-webpack-server start",
-    "hot": "HOT=1 node ../../bin/react-native-webpack-server start --hot"
+    "start": "react-native-webpack-server start",
+    "hot": "HOT=1 react-native-webpack-server start --hot"
   },
   "dependencies": {
     "cjsx-loader": "^2.0.1",
@@ -12,7 +12,8 @@
     "coffee-script": "^1.9.1",
     "react": "^0.13.1",
     "react-hot-loader": "^1.2.4",
-    "react-native": ">=0.4.3",
+    "react-native": "^0.9.0",
+    "react-native-webpack-server": "^0.3.0",
     "webpack": "^1.8.4",
     "webpack-dev-server": "^1.8.0"
   }

--- a/Examples/CoffeeScript/webpack.config.js
+++ b/Examples/CoffeeScript/webpack.config.js
@@ -34,7 +34,7 @@ var config = {
 // Hot loader
 if (process.env.HOT) {
   config.devtool = 'eval'; // Speed up incremental builds
-  config.entry['index.ios'].unshift('../../hot/entry');
+  config.entry['index.ios'].unshift('react-native-webpack-server/hot/entry');
   config.entry['index.ios'].unshift('webpack/hot/only-dev-server');
   config.entry['index.ios'].unshift('webpack-dev-server/client?http://localhost:8082');
   config.output.publicPath = 'http://localhost:8082/';

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Start the React Native Webpack Server using the included script. You might want 
 
 ```js
 "scripts": {
-  "start": "./node_modules/.bin/react-native-webpack-server start"
+  "start": "react-native-webpack-server start"
 }
 ```
 


### PR DESCRIPTION
This makes it easier for people to use the example projects as templates for new projects, without requiring that react-native-webpack-server is in the upper directory.
