### PR TITLE
Fix RCTRootView.initWithBundleURL signature in examples for RN 0.11

### DIFF
--- a/Examples/BabelES6/iOS/AppDelegate.m
+++ b/Examples/BabelES6/iOS/AppDelegate.m
@@ -38,6 +38,7 @@
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"BabelES6"
+                                               initialProperties:nil
                                                    launchOptions:launchOptions];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];

--- a/Examples/BabelES6/package.json
+++ b/Examples/BabelES6/package.json
@@ -12,7 +12,7 @@
     "babel-loader": "^5.0.0",
     "react": "^0.13.1",
     "react-hot-loader": "^1.2.4",
-    "react-native": ">=0.4.3",
+    "react-native": ">=0.11.0",
     "webpack": "^1.8.4",
     "webpack-dev-server": "^1.8.0"
   }

--- a/Examples/CoffeeScript/iOS/AppDelegate.m
+++ b/Examples/CoffeeScript/iOS/AppDelegate.m
@@ -38,6 +38,7 @@
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"CoffeeScript"
+                                               initialProperties:nil
                                                    launchOptions:launchOptions];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];

--- a/Examples/CoffeeScript/package.json
+++ b/Examples/CoffeeScript/package.json
@@ -12,7 +12,7 @@
     "coffee-script": "^1.9.1",
     "react": "^0.13.1",
     "react-hot-loader": "^1.2.4",
-    "react-native": ">=0.4.3",
+    "react-native": ">=0.11.0",
     "webpack": "^1.8.4",
     "webpack-dev-server": "^1.8.0"
   }


### PR DESCRIPTION
This fixes the examples to build in React Native 0.11.
The signature changed in https://github.com/facebook/react-native/commit/261f9434e54274a68d2cb50644c436197ef48baa.
