### PR TITLE
Bundle + More reliable startup....

### DIFF
--- a/bin/react-native-webpack-server.js
+++ b/bin/react-native-webpack-server.js
@@ -4,9 +4,10 @@ var path = require('path');
 var fs = require('fs');
 var parser = require('nomnom');
 var Server = require('../lib/Server');
+var fetch = require('../lib/fetch');
 
-parser.command('start')
-  .option('hostname', {
+function commonOptions (command) {
+  return command.option('hostname', {
     default: 'localhost',
   })
   .option('port', {
@@ -23,22 +24,52 @@ parser.command('start')
   })
   .option('webpackConfigPath', {
     default: 'webpack.config.js',
-  })
+  });
+}
+
+function startServer(opts) {
+  opts.webpackConfigPath = path.resolve(process.cwd(), opts.webpackConfigPath);
+  if (fs.existsSync(opts.webpackConfigPath)) {
+    opts.webpackConfig = require(path.resolve(process.cwd(), opts.webpackConfigPath));
+  } else {
+    throw new Error('Must specify webpackConfigPath or create ./webpack.config.js');
+    process.exit(1);
+  }
+  delete opts.webpackConfigPath;
+
+  var server = new Server(opts);
+  return server;
+}
+
+commonOptions(parser.command('start')
   .option('hot', {
     flag: true,
     default: false,
-  })
+  }))
   .callback(function(opts) {
-    opts.webpackConfigPath = path.resolve(process.cwd(), opts.webpackConfigPath);
-    if (fs.existsSync(opts.webpackConfigPath)) {
-      opts.webpackConfig = require(path.resolve(process.cwd(), opts.webpackConfigPath));
-    } else {
-      throw new Error('Must specify webpackConfigPath or create ./webpack.config.js');
-      process.exit(1);
-    }
-    delete opts.webpackConfigPath;
+    var server = startServer(opts);
+    server.start();
+  });
 
-    (new Server(opts)).start();
+commonOptions(parser.command('bundle'))
+  .callback(function(opts) {
+    var server = startServer(opts);
+    var url = 'http://localhost:' + opts.port + '/index.ios.bundle';
+    var targetPath = path.resolve('./iOS/main.jsbundle');
+
+    server.start();
+
+    fetch(url).then(function(content) {
+      fs.writeFileSync(targetPath, content);
+      server.stop();
+
+      // XXX: Hack something is keeping the process alive but we can still
+      // safely kill here without leaving processes hanging around...
+      process.exit(0);
+    }).catch(function(err) {
+      console.log('Error creating bundle...', err.stack);
+      server.stop();
+    });
   });
 
 parser.parse();

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -13,30 +13,11 @@ var webpack = require('webpack');
 var WebpackDevServer = require('webpack-dev-server');
 var getReactNativeExternals = require('./getReactNativeExternals');
 var waitForSocket = require('socket-retry-connect').waitForSocket;
+var fetch = require('./fetch');
 
 var ENTRY_JS = 'global.React = require("react-native");';
 var SOURCEMAP_REGEX = /\/\/[#@] sourceMappingURL=([^\s'"]*)/;
 var WEBPACK_EXTERNAL_REGEX = /external\s"([^"]+)"/;
-
-function fetch(uri) {
-  return new Promise(function(resolve, reject) {
-    var parts = url.parse(uri);
-    var buffer = '';
-    var handler = function(res) {
-      res.on('data', function(chunk) {
-        buffer += chunk;
-      });
-      res.on('end', function() {
-        if (res.statusCode === 200) {
-          resolve(buffer);
-        } else {
-          reject(buffer);
-        }
-      });
-    };
-    http.request(parts, handler).end();
-  });
-}
 
 function parseQueryParams(req) {
   var parts = url.parse(req.url);
@@ -182,11 +163,12 @@ function Server(options) {
     process.exit(1);
   }.bind(this));
 
+
   // Construct a promise waiting for both servers to fully start...
-  this._readyPromise = Promise.all([
-    this._startPackageServer(),
-    this._startWebpackDevServer()
-  ]).then(function() {
+  this._readyPromise = this._startWebpackDevServer().then(function() {
+    // We need to start this one second to prevent races between the bundlers.
+    return this._startPackageServer();
+  }.bind(this)).then(function() {
     this._readyPromise = null;
   }.bind(this));
 }
@@ -196,9 +178,15 @@ Server.prototype = {
   start: function() {
     var hostname = this.hostname;
     var port = this.port;
-    http.createServer(this.server).listen(this.port, function() {
+    this.httpServer = http.createServer(this.server).listen(this.port, function() {
       console.log('Server listening at http://%s:%s', hostname, port);
     });
+  },
+
+  stop: function() {
+    this.handleProcessExit();
+    this.httpServer && this.httpServer.close();
+    this.webpackServerHttp && this.webpackServerHttp.close();
   },
 
   handleRequest: function(req, res, next) {
@@ -334,8 +322,11 @@ Server.prototype = {
      */
     return new Promise(function (accept, reject) {
       // Easier to just shell out to the packager than use the JS API.
-      var cmd = './node_modules/react-native/packager/packager.sh';
+      // XXX: Uses the node only invocation so we don't have to deal with bash
+      // as well... Fixes issues where server cannot be killed cleanly.
+      var cmd = 'node';
       var args = [
+        './node_modules/react-native/packager/packager.js',
         '--root', path.resolve(process.cwd(), 'node_modules/react-native'),
         '--root', this.entryDir,
         '--port', this.packagerPort,
@@ -415,7 +406,7 @@ Server.prototype = {
           stats: {colors: true, chunkModules: false}
         });
 
-        this.webpackServer.listen(this.webpackPort, this.hostname, function() {
+        this.webpackServerHttp = this.webpackServer.listen(this.webpackPort, this.hostname, function() {
           console.log('Webpack dev server listening at ', webpackURL);
         });
       }.bind(this));

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -12,6 +12,7 @@ var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var webpack = require('webpack');
 var WebpackDevServer = require('webpack-dev-server');
 var getReactNativeExternals = require('./getReactNativeExternals');
+var waitForSocket = require('socket-retry-connect').waitForSocket;
 
 var ENTRY_JS = 'global.React = require("react-native");';
 var SOURCEMAP_REGEX = /\/\/[#@] sourceMappingURL=([^\s'"]*)/;
@@ -176,11 +177,18 @@ function Server(options) {
 
   // Make sure to clean up when the process is terminated.
   process.on('exit', this.handleProcessExit.bind(this));
-  process.on('SIGINT', process.exit.bind(process));
+  process.on('SIGINT', function() {
+    this.handleProcessExit();
+    process.exit(1);
+  }.bind(this));
 
-  // Spin up the RN packager and webpack servers.
-  this._startWebpackDevServer()
-    .then(this._startPackageServer.bind(this));
+  // Construct a promise waiting for both servers to fully start...
+  this._readyPromise = Promise.all([
+    this._startPackageServer(),
+    this._startWebpackDevServer()
+  ]).then(function() {
+    this._readyPromise = null;
+  }.bind(this));
 }
 
 Server.prototype = {
@@ -194,6 +202,14 @@ Server.prototype = {
   },
 
   handleRequest: function(req, res, next) {
+    // If we are still booting the server wait for it to finish...
+    if (this._readyPromise) {
+      this._readyPromise.then(
+        this.handleRequest.bind(this, req, res, next)
+      );
+      return;
+    }
+
     var parts = url.parse(req.url);
     var pathname = parts.pathname;
     switch (pathname) {
@@ -311,15 +327,38 @@ Server.prototype = {
   },
 
   _startPackageServer: function() {
-    // Easier to just shell out to the packager than use the JS API.
-    var cmd = './node_modules/react-native/packager/packager.sh';
-    var args = [
-      '--root', path.resolve(process.cwd(), 'node_modules/react-native'),
-      '--root', this.entryDir,
-      '--port', this.packagerPort,
-    ];
-    var opts = {stdio: 'inherit'};
-    this.packageServer = spawn(cmd, args, opts);
+    /**
+     * Starting the server is neither fast nor completely reliable we end up
+     * hitting its public api over http periodically so we must wait for it to
+     * be actually ready.
+     */
+    return new Promise(function (accept, reject) {
+      // Easier to just shell out to the packager than use the JS API.
+      var cmd = './node_modules/react-native/packager/packager.sh';
+      var args = [
+        '--root', path.resolve(process.cwd(), 'node_modules/react-native'),
+        '--root', this.entryDir,
+        '--port', this.packagerPort,
+      ];
+      var opts = {stdio: 'inherit'};
+      this.packageServer = spawn(cmd, args, opts);
+
+      function handleError(err) {
+        reject(err);
+      }
+
+      this.packageServer.on('error', handleError);
+
+      waitForSocket({ port: this.packagerPort }, function(err) {
+        console.log('react-native packager ready...');
+        this.packageServer.removeListener('error', handleError);
+        if (err) {
+          handleError(err);
+          return;
+        }
+        accept();
+      }.bind(this));
+    }.bind(this));
   },
 
   _startWebpackDevServer: function() {

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,0 +1,24 @@
+var http = require('http');
+var url = require('url');
+
+function fetch(uri) {
+  return new Promise(function(resolve, reject) {
+    var parts = url.parse(uri);
+    var buffer = '';
+    var handler = function(res) {
+      res.on('data', function(chunk) {
+        buffer += chunk;
+      });
+      res.on('end', function() {
+        if (res.statusCode === 200) {
+          resolve(buffer);
+        } else {
+          reject(buffer);
+        }
+      });
+    };
+    http.request(parts, handler).end();
+  });
+}
+
+module.exports = fetch;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "bluebird": "^2.9.24",
     "connect": "^3.3.5",
     "source-map": "^0.4.2",
-    "nomnom": "^1.8.1"
+    "nomnom": "^1.8.1",
+    "socket-retry-connect": "0.0.1"
   }
 }


### PR DESCRIPTION
To get closer to react-native bundler parity we needed to add the`bundle` command but when we where initially testing this module out we also found some races in the startup path... With this PR the server starts immediately but will wait until the other dependent servers are running before attempting to send them requests.
