### PR TITLE
Replace React Hot Loader with React Transform (breaking change!)

### DIFF
--- a/Examples/BabelES6/package.json
+++ b/Examples/BabelES6/package.json
@@ -10,8 +10,10 @@
     "babel": "^5.1.4",
     "babel-core": "^5.1.4",
     "babel-loader": "^5.0.0",
+    "babel-plugin-react-transform": "^1.0.5",
     "react-native": "^0.11.0",
     "react-native-webpack-server": "^0.4.0",
+    "react-transform-webpack-hmr": "^0.1.5",
     "webpack": "^1.8.4",
     "webpack-dev-server": "^1.8.0"
   }

--- a/Examples/BabelES6/package.json
+++ b/Examples/BabelES6/package.json
@@ -10,8 +10,6 @@
     "babel": "^5.1.4",
     "babel-core": "^5.1.4",
     "babel-loader": "^5.0.0",
-    "react": "^0.13.1",
-    "react-hot-loader": "^1.2.4",
     "react-native": "^0.11.0",
     "react-native-webpack-server": "^0.4.0",
     "webpack": "^1.8.4",

--- a/Examples/BabelES6/webpack.config.js
+++ b/Examples/BabelES6/webpack.config.js
@@ -34,7 +34,6 @@ if (process.env.HOT) {
   config.entry['index.ios'].unshift('webpack/hot/only-dev-server');
   config.entry['index.ios'].unshift('webpack-dev-server/client?http://localhost:8082');
   config.output.publicPath = 'http://localhost:8082/';
-  config.module.loaders[0].loaders.unshift('react-hot');
   config.plugins.unshift(new webpack.HotModuleReplacementPlugin());
 }
 

--- a/Examples/BabelES6/webpack.config.js
+++ b/Examples/BabelES6/webpack.config.js
@@ -18,9 +18,15 @@ var config = {
   },
 
   module: {
-    loaders: [
-      {test: /\.js$/, exclude: /node_modules/, loaders: ['babel?stage=0&blacklist=validation.react']},
-    ],
+    loaders: [{
+      test: /\.js$/,
+      exclude: /node_modules/,
+      loader: 'babel',
+      query: {
+        stage: 0,
+        plugins: []
+      }
+    }]
   },
 
   plugins: [],
@@ -35,6 +41,14 @@ if (process.env.HOT) {
   config.entry['index.ios'].unshift('webpack-dev-server/client?http://localhost:8082');
   config.output.publicPath = 'http://localhost:8082/';
   config.plugins.unshift(new webpack.HotModuleReplacementPlugin());
+  config.module.loaders[0].query.plugins.push('react-transform');
+  config.module.loaders[0].query.extra = {
+    'react-transform': [{
+      target: 'react-transform-webpack-hmr',
+      imports: ['react-native'],
+      locals: ['module']
+    }]
+  };
 }
 
 // Production config

--- a/Examples/CoffeeScript/package.json
+++ b/Examples/CoffeeScript/package.json
@@ -7,11 +7,15 @@
     "hot": "HOT=1 react-native-webpack-server start --hot"
   },
   "dependencies": {
+    "babel-core": "^5.8.24",
+    "babel-loader": "^5.3.2",
+    "babel-plugin-react-transform": "^1.0.5",
     "cjsx-loader": "^2.0.1",
     "coffee-loader": "^0.7.2",
     "coffee-script": "^1.9.1",
     "react-native": "^0.11.0",
     "react-native-webpack-server": "^0.4.0",
+    "react-transform-webpack-hmr": "^0.1.5",
     "webpack": "^1.8.4",
     "webpack-dev-server": "^1.8.0"
   }

--- a/Examples/CoffeeScript/package.json
+++ b/Examples/CoffeeScript/package.json
@@ -10,8 +10,6 @@
     "cjsx-loader": "^2.0.1",
     "coffee-loader": "^0.7.2",
     "coffee-script": "^1.9.1",
-    "react": "^0.13.1",
-    "react-hot-loader": "^1.2.4",
     "react-native": "^0.11.0",
     "react-native-webpack-server": "^0.4.0",
     "webpack": "^1.8.4",

--- a/Examples/CoffeeScript/src/components/App.coffee
+++ b/Examples/CoffeeScript/src/components/App.coffee
@@ -12,16 +12,15 @@ getTransformMatrix = (rotation) ->
   m2 = mat4.rotateZ m2, m1, rotation
   [].slice.apply m2
 
-class App extends React.Component
+App = React.createClass
 
-  constructor: (props) ->
-    super props
-    @state = {rotation: 0}
+  getInitialState: () ->
+    {rotation: 0}
 
   componentDidMount: ->
     do @onTick
 
-  onTick: =>
+  onTick: ->
     inc = 1
     degrees = radiansToDegrees(@state.rotation) - inc
     rotation = degressToRadians degrees

--- a/Examples/CoffeeScript/webpack.config.js
+++ b/Examples/CoffeeScript/webpack.config.js
@@ -39,6 +39,21 @@ if (process.env.HOT) {
   config.entry['index.ios'].unshift('webpack-dev-server/client?http://localhost:8082');
   config.output.publicPath = 'http://localhost:8082/';
   config.plugins.unshift(new webpack.HotModuleReplacementPlugin());
+  config.module.loaders.unshift({
+    test: /\.coffee$/,
+    exclude: /node_modules/,
+    loader: 'babel',
+    query: {
+      plugins: ['react-transform'],
+      extra: {
+        'react-transform': [{
+          target: 'react-transform-webpack-hmr',
+          imports: ['react-native'],
+          locals: ['module']
+        }]
+      }
+    }
+  });
 }
 
 // Production config

--- a/Examples/CoffeeScript/webpack.config.js
+++ b/Examples/CoffeeScript/webpack.config.js
@@ -38,7 +38,6 @@ if (process.env.HOT) {
   config.entry['index.ios'].unshift('webpack/hot/only-dev-server');
   config.entry['index.ios'].unshift('webpack-dev-server/client?http://localhost:8082');
   config.output.publicPath = 'http://localhost:8082/';
-  config.module.loaders[0].loaders.unshift('react-hot');
   config.plugins.unshift(new webpack.HotModuleReplacementPlugin());
 }
 

--- a/hot/entry.js
+++ b/hot/entry.js
@@ -1,11 +1,4 @@
 if (module.hot) {
-  var ReactNativeMount = require('ReactNativeMount');
-  var HotLoaderInjection = require('react-hot-loader/Injection');
-  HotLoaderInjection.RootInstanceProvider.injectProvider({
-    getRootInstances: function() {
-      return ReactNativeMount._instancesByContainerID;
-    }
-  });
   //! Terrible hack to marshall WS messages onto React Native's event loop.
   setInterval(function() {}, 200);
 }

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -98,21 +98,6 @@ function getEntryModules(allModules, reactNativeExternals) {
 }
 
 function makeHotConfig(webpackConfig) {
-  // Ensure react-hot-loader is installed.
-  if (!fs.existsSync(path.resolve(process.cwd(), 'node_modules/react-hot-loader'))) {
-    console.error('Please install react-hot-loader first.');
-    process.exit(1);
-  }
-
-  // Setup alias into project's node_modules/react-hot-loader. We can't use
-  // require('react-hot-loader') in the hot entry.js since webpack will look
-  // in our own node_modules directory and we would have the same problem
-  // with requiring external React.
-  webpackConfig.resolve = webpackConfig.resolve || {};
-  webpackConfig.resolve.alias = webpackConfig.resolve.alias || {};
-  webpackConfig.resolve.alias['react-hot-loader/Injection'] =
-    path.resolve(process.cwd(), 'node_modules/react-hot-loader/Injection');
-
   // Restore document.createElement (see: InitializeJavaScriptAppEngine.js)
   webpackConfig.plugins = webpackConfig.plugins || [];
   webpackConfig.plugins.unshift(

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "README.md"
   ],
   "peerDependencies": {
-    "react-hot-loader": ">=1.2.4",
     "react-native": ">=0.11.0",
     "webpack": ">=1.8.4",
     "webpack-dev-server": ">=1.8.0"


### PR DESCRIPTION
This removes built-in dependency on React Hot Loader for hot reloading. Instead of doing magic with injection and aliasing `react`, the hot reloading now works via [babel-plugin-react-transform](https://github.com/gaearon/babel-plugin-react-transform) + [react-transform-webpack-hmr](https://github.com/gaearon/react-transform-webpack-hmr).

**This is a breaking change.**
1. CoffeeScript example now needs to be processed via Babel too, and we have to give up class syntax there because `babel-plugin-react-transform` won't recognize CoffeeScript classes in the compiled output. This is fixable long-term by implementing a CoffeeScript parser for Babel, or by implementing `react-transform-loader` that would look into `module.exports` for classes to patch, just like React Hot Loader previously did it. I don't think it's a big issue, and if it's an inconvenience for CoffeeScript community, I'll be happy to guide help somebody through implementing `react-transform-loader` as suggested above.
2. We no longer support React Hot Loader! And that's a good thing because it's going to be deprecated and won't be maintained. `react-transform-webpack-hmr` is much better: it can handle multiple components in one file, it keeps the state when you wrap component in a HOC, it doesn't require `react` package so you can remove it from dependencies, and it supports ES6 features like getters—it works on top of [React Proxy](https://github.com/gaearon/react-proxy) which is 100% covered by tests, unlike React Hot Loader.

There is one more important note. Instead of putting configuration into `.babelrc`, I left it inline in Webpack config. There are <s>two</s> three reasons for this:
1. We don't want to process React Native sources with `babel-plugin-react-transform`, but packager would use `.babelrc` if it was provided
2. It's easy to check that we're in hot environment from `webpack.config.js`—not so easy from `.babelrc` because it can only read `NODE_ENV`
3. Changes in `.babelrc` require jumping through hoops to pick up (https://github.com/mjohnston/react-native-webpack-server/issues/63)

What do you think?
I have not tested _extensively_ but this should work.

Fixes #55.
