### PR TITLE
react-transform-webpack-hmr was renamed to react-transform-hmr

### DIFF
--- a/Examples/BabelES6/package.json
+++ b/Examples/BabelES6/package.json
@@ -14,7 +14,7 @@
     "babel-plugin-react-transform": "^1.0.5",
     "react-native": "^0.11.0",
     "react-native-webpack-server": "^0.4.0",
-    "react-transform-webpack-hmr": "^0.1.5",
+    "react-transform-hmr": "^0.1.5",
     "webpack": "^1.8.4",
     "webpack-dev-server": "^1.8.0"
   }

--- a/Examples/BabelES6/webpack.config.js
+++ b/Examples/BabelES6/webpack.config.js
@@ -44,7 +44,7 @@ if (process.env.HOT) {
   config.module.loaders[0].query.plugins.push('react-transform');
   config.module.loaders[0].query.extra = {
     'react-transform': [{
-      target: 'react-transform-webpack-hmr',
+      target: 'react-transform-hmr',
       imports: ['react-native'],
       locals: ['module']
     }]

--- a/Examples/CoffeeScript/package.json
+++ b/Examples/CoffeeScript/package.json
@@ -16,7 +16,7 @@
     "coffee-script": "^1.9.1",
     "react-native": "^0.11.0",
     "react-native-webpack-server": "^0.4.0",
-    "react-transform-webpack-hmr": "^0.1.5",
+    "react-transform-hmr": "^0.1.5",
     "webpack": "^1.8.4",
     "webpack-dev-server": "^1.8.0"
   }

--- a/Examples/CoffeeScript/webpack.config.js
+++ b/Examples/CoffeeScript/webpack.config.js
@@ -47,7 +47,7 @@ if (process.env.HOT) {
       plugins: ['react-transform'],
       extra: {
         'react-transform': [{
-          target: 'react-transform-webpack-hmr',
+          target: 'react-transform-hmr',
           imports: ['react-native'],
           locals: ['module']
         }]

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ React Native Webpack Server enables source maps by generating the react-native a
 
 ## Hot Reload
 
-Since this is built on Webpack you can now leverage the growing ecosystem of addons such as React hot module replacement via [react-transform-webpack-hmr](https://github.com/gaearon/react-transform-webpack-hmr).
+Since this is built on Webpack you can now leverage the growing ecosystem of addons such as React hot module replacement via [react-transform-hmr](https://github.com/gaearon/react-transform-hmr).
 
-To enable hot reload, make sure you first install [babel-plugin-react-transform](https://github.com/gaearon/babel-plugin-react-transform) and [react-transform-webpack-hmr](https://github.com/gaearon/react-transform-webpack-hmr), then start the server with `--hot`.
+To enable hot reload, make sure you first install [babel-plugin-react-transform](https://github.com/gaearon/babel-plugin-react-transform) and [react-transform-hmr](https://github.com/gaearon/react-transform-hmr), then start the server with `--hot`.
 
 You'll also need to configure Webpack. See the [Babel+ES6 config](https://github.com/mjohnston/react-native-webpack-server/blob/master/Examples/BabelES6/webpack.config.js) for an example.
 


### PR DESCRIPTION
The old package still works but `console.error`-s a deprecation warning.
Sorry for the churn!
