### PR TITLE
Update babel-plugin-react-transform and related configs

### DIFF
--- a/Examples/BabelES6/package.json
+++ b/Examples/BabelES6/package.json
@@ -11,7 +11,7 @@
     "babel": "^5.1.4",
     "babel-core": "^5.1.4",
     "babel-loader": "^5.0.0",
-    "babel-plugin-react-transform": "^1.0.5",
+    "babel-plugin-react-transform": "^1.1.0",
     "react-native": "^0.11.0",
     "react-native-webpack-server": "^0.4.0",
     "react-transform-hmr": "^0.1.5",

--- a/Examples/BabelES6/webpack.config.js
+++ b/Examples/BabelES6/webpack.config.js
@@ -43,11 +43,13 @@ if (process.env.HOT) {
   config.plugins.unshift(new webpack.HotModuleReplacementPlugin());
   config.module.loaders[0].query.plugins.push('react-transform');
   config.module.loaders[0].query.extra = {
-    'react-transform': [{
-      target: 'react-transform-hmr',
-      imports: ['react-native'],
-      locals: ['module']
-    }]
+    'react-transform': {
+      transforms: [{
+        transform: 'react-transform-hmr',
+        imports: ['react-native'],
+        locals: ['module']
+      }]
+    }
   };
 }
 

--- a/Examples/CoffeeScript/package.json
+++ b/Examples/CoffeeScript/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "babel-core": "^5.8.24",
     "babel-loader": "^5.3.2",
-    "babel-plugin-react-transform": "^1.0.5",
+    "babel-plugin-react-transform": "^1.1.0",
     "cjsx-loader": "^2.0.1",
     "coffee-loader": "^0.7.2",
     "coffee-script": "^1.9.1",

--- a/Examples/CoffeeScript/webpack.config.js
+++ b/Examples/CoffeeScript/webpack.config.js
@@ -46,11 +46,13 @@ if (process.env.HOT) {
     query: {
       plugins: ['react-transform'],
       extra: {
-        'react-transform': [{
-          target: 'react-transform-hmr',
-          imports: ['react-native'],
-          locals: ['module']
-        }]
+        'react-transform': {
+          transforms: [{
+            transform: 'react-transform-hmr',
+            imports: ['react-native'],
+            locals: ['module']
+          }]
+        }
       }
     }
   });


### PR DESCRIPTION
This updates the configs to incorporate the changes in https://github.com/gaearon/babel-plugin-react-transform/releases/tag/v1.1.0. The old format is still supported but logs a warning, so it wasn't a breaking change.
