### PR TITLE
Convert to Node-v2-compatible ES6

### DIFF
--- a/bin/react-native-webpack-server.js
+++ b/bin/react-native-webpack-server.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-var path = require('path');
-var fs = require('fs');
-var parser = require('nomnom');
-var Server = require('../lib/Server');
-var fetch = require('../lib/fetch');
+const path = require('path');
+const fs = require('fs');
+const parser = require('nomnom');
+const Server = require('../lib/Server');
+const fetch = require('../lib/fetch');
 
 function commonOptions (command) {
   return command.option('hostname', {
@@ -27,7 +27,7 @@ function commonOptions (command) {
   });
 }
 
-function startServer(opts) {
+function createServer(opts) {
   opts.webpackConfigPath = path.resolve(process.cwd(), opts.webpackConfigPath);
   if (fs.existsSync(opts.webpackConfigPath)) {
     opts.webpackConfig = require(path.resolve(process.cwd(), opts.webpackConfigPath));
@@ -37,25 +37,25 @@ function startServer(opts) {
   }
   delete opts.webpackConfigPath;
 
-  var server = new Server(opts);
+  const server = new Server(opts);
   return server;
 }
 
-commonOptions(parser.command('start')
+commonOptions(parser.command('start'))
   .option('hot', {
     flag: true,
     default: false,
-  }))
+  })
   .callback(function(opts) {
-    var server = startServer(opts);
+    const server = createServer(opts);
     server.start();
   });
 
 commonOptions(parser.command('bundle'))
   .callback(function(opts) {
-    var server = startServer(opts);
-    var url = 'http://localhost:' + opts.port + '/index.ios.bundle';
-    var targetPath = path.resolve('./iOS/main.jsbundle');
+    const server = createServer(opts);
+    const url = 'http://localhost:' + opts.port + '/index.ios.bundle';
+    const targetPath = path.resolve('./iOS/main.jsbundle');
 
     server.start();
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1,27 +1,27 @@
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
-var http = require('http');
-var url = require('url');
-var connect = require('connect');
-var spawn = require('child_process').spawn;
-var Promise = require('bluebird');
-var SourceNode = require('source-map').SourceNode;
-var SourceMapConsumer = require('source-map').SourceMapConsumer;
-var webpack = require('webpack');
-var WebpackDevServer = require('webpack-dev-server');
-var getReactNativeExternals = require('./getReactNativeExternals');
-var waitForSocket = require('socket-retry-connect').waitForSocket;
-var fetch = require('./fetch');
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const url = require('url');
+const connect = require('connect');
+const spawn = require('child_process').spawn;
+const Promise = require('bluebird');
+const SourceNode = require('source-map').SourceNode;
+const SourceMapConsumer = require('source-map').SourceMapConsumer;
+const webpack = require('webpack');
+const WebpackDevServer = require('webpack-dev-server');
+const getReactNativeExternals = require('./getReactNativeExternals');
+const waitForSocket = require('socket-retry-connect').waitForSocket;
+const fetch = require('./fetch');
 
-var ENTRY_JS = 'global.React = require("react-native");';
-var SOURCEMAP_REGEX = /\/\/[#@] sourceMappingURL=([^\s'"]*)/;
-var WEBPACK_EXTERNAL_REGEX = /external\s"([^"]+)"/;
+const ENTRY_JS = 'global.React = require("react-native");';
+const SOURCEMAP_REGEX = /\/\/[#@] sourceMappingURL=([^\s'"]*)/;
+const WEBPACK_EXTERNAL_REGEX = /external\s"([^"]+)"/;
 
 function parseQueryParams(req) {
-  var parts = url.parse(req.url);
-  var params = {};
+  const parts = url.parse(req.url);
+  const params = {};
 
   if (parts.query) {
     parts.query.split('&').forEach(function(pair) {
@@ -58,9 +58,9 @@ function staticImageTransform(context, request, callback) {
 }
 
 function resolveReactNativeModule(webpackId, reactNativeExternals) {
-  var matches = webpackId.match(WEBPACK_EXTERNAL_REGEX);
+  const matches = webpackId.match(WEBPACK_EXTERNAL_REGEX);
   if (matches && matches.length > 1) {
-    var module = matches[1];
+    const module = matches[1];
     return reactNativeExternals[module] ? module : null;
   }
   return null;
@@ -97,87 +97,85 @@ function makeHotConfig(webpackConfig) {
   );
 }
 
-/**
- * Create a new server with the following options:
- * {String} hostname (default localhost)
- * {Number} port (default 8080)
- * {Number} packagerPort (default 8081)
- * {Number} webpackPort (default 8082)
- * {String} entry (default index.ios)
- * {Object} webpackConfig (default require(./webpack.config.js))
- * {Boolean} hot enable react-hot-loader (default false)
- *
- * @constructor
- * @param {Object} options
- */
-function Server(options) {
-  if (!options) options = {};
+class Server {
 
-  // Default options
-  this.hostname = options.hostname || 'localhost';
-  this.port = options.port || 8080;
-  this.packagerPort = options.packagerPort || 8081;
-  this.webpackPort = options.webpackPort || 8082;
-  this.entry = options.entry || 'index.ios';
-  this.hot = (options.hot === true);
-  this.webpackConfig = options.webpackConfig;
+  /**
+   * Create a new server with the following options:
+   * @param {String}  hostname (default localhost)
+   * @param {Number}  port (default 8080)
+   * @param {Number}  packagerPort (default 8081)
+   * @param {Number}  webpackPort (default 8082)
+   * @param {String}  entry (default index.ios)
+   * @param {Object}  webpackConfig (default require(./webpack.config.js))
+   * @param {Boolean} hot enable react-hot-loader (default false)
+   *
+   * @constructor
+   * @param {Object} options
+   */
+  constructor(options) {
+    if (!options) options = {};
 
-  // Check for local react-native.
-  if (!fs.existsSync(path.resolve(process.cwd(), 'node_modules/react-native'))) {
-    throw new Error('Could not find react-native. Try `npm install react-native`.');
-    process.exit(1);
+    // Default options
+    this.hostname = options.hostname || 'localhost';
+    this.port = options.port || 8080;
+    this.packagerPort = options.packagerPort || 8081;
+    this.webpackPort = options.webpackPort || 8082;
+    this.entry = options.entry || 'index.ios';
+    this.hot = (options.hot === true);
+    this.webpackConfig = options.webpackConfig;
+
+    // Check for local react-native.
+    if (!fs.existsSync(path.resolve(process.cwd(), 'node_modules/react-native'))) {
+      throw new Error('Could not find react-native. Try `npm install react-native`.');
+    }
+
+    // Construct resource URLs up-front
+    this.webpackBaseURL = url.format({protocol: 'http', hostname: this.hostname, port: this.webpackPort});
+    this.packagerBaseURL = url.format({protocol: 'http', hostname: this.hostname, port: this.packagerPort});
+    this.reactCodeURL = url.resolve(this.packagerBaseURL, `${this.entry}.bundle`);
+    this.reactMapURL = url.resolve(this.packagerBaseURL, `${this.entry}.map`);
+    this.appCodeURL = url.resolve(this.webpackBaseURL, `${this.entry}.js`);
+    this.appMapURL = url.resolve(this.webpackBaseURL, `${this.entry}.js.map`);
+
+    // Setup the connect server
+    this.server = connect();
+    this.server.use(this.handleRequest.bind(this));
+
+    // Create a stub entry module for the RN packager.
+    this.entryDir = path.resolve(__dirname, '../_entry');
+    this._writeEntryFile();
+
+    // Make sure to clean up when the process is terminated.
+    process.on('exit', this.handleProcessExit.bind(this));
+    process.on('SIGINT', function() {
+      this.handleProcessExit();
+      process.exit(1);
+    }.bind(this));
+
+    // Construct a promise waiting for both servers to fully start...
+    this._readyPromise = this._startWebpackDevServer().then(function() {
+      // We need to start this one second to prevent races between the bundlers.
+      return this._startPackageServer();
+    }.bind(this)).then(function() {
+      this._readyPromise = null;
+    }.bind(this));
   }
 
-  // Construct resource URLs up-front
-  this.webpackBaseURL = 'http://' + this.hostname + ':' + this.webpackPort;
-  this.packagerBaseURL = 'http://' + this.hostname + ':' + this.packagerPort;
-  this.reactCodeURL = this.packagerBaseURL + '/' + this.entry + '.bundle';
-  this.reactMapURL = this.packagerBaseURL + '/' + this.entry + '.map';
-  this.appCodeURL = this.webpackBaseURL + '/' + this.entry + '.js';
-  this.appMapURL = this.webpackBaseURL + '/' + this.entry + '.js.map';
-
-  // Setup the connect server
-  this.server = connect();
-  this.server.use(this.handleRequest.bind(this));
-
-  // Create a stub entry module for the RN packager.
-  this.entryDir = path.resolve(__dirname, '../_entry');
-  this._writeEntryFile();
-
-  // Make sure to clean up when the process is terminated.
-  process.on('exit', this.handleProcessExit.bind(this));
-  process.on('SIGINT', function() {
-    this.handleProcessExit();
-    process.exit(1);
-  }.bind(this));
-
-
-  // Construct a promise waiting for both servers to fully start...
-  this._readyPromise = this._startWebpackDevServer().then(function() {
-    // We need to start this one second to prevent races between the bundlers.
-    return this._startPackageServer();
-  }.bind(this)).then(function() {
-    this._readyPromise = null;
-  }.bind(this));
-}
-
-Server.prototype = {
-
-  start: function() {
-    var hostname = this.hostname;
-    var port = this.port;
-    this.httpServer = http.createServer(this.server).listen(this.port, function() {
+  start() {
+    const hostname = this.hostname;
+    const port = this.port;
+    this.httpServer = http.createServer(this.server).listen(port, function() {
       console.log('Server listening at http://%s:%s', hostname, port);
     });
-  },
+  }
 
-  stop: function() {
+  stop() {
     this.handleProcessExit();
     this.httpServer && this.httpServer.close();
     this.webpackServerHttp && this.webpackServerHttp.close();
-  },
+  }
 
-  handleRequest: function(req, res, next) {
+  handleRequest(req, res, next) {
     // If we are still booting the server wait for it to finish...
     if (this._readyPromise) {
       this._readyPromise.then(
@@ -186,28 +184,28 @@ Server.prototype = {
       return;
     }
 
-    var parts = url.parse(req.url);
-    var pathname = parts.pathname;
+    const parts = url.parse(req.url);
+    const pathname = parts.pathname;
     switch (pathname) {
-      case ('/' + this.entry + '.bundle'):
-        this.handleBundleRequest(req, res, next);
-        break;
-      case ('/' + this.entry + '.map'):
-        this.handleMapRequest(req, res, next);
-        break;
-      default:
-        res.writeHead(404);
-        res.end('Cannot GET ' + req.url);
+    case ('/' + this.entry + '.bundle'):
+      this.handleBundleRequest(req, res, next);
+      break;
+    case ('/' + this.entry + '.map'):
+      this.handleMapRequest(req, res, next);
+      break;
+    default:
+      res.writeHead(404);
+      res.end('Cannot GET ' + req.url);
     }
-  },
+  }
 
-  handleBundleRequest: function(req, res, next) {
-    var createBundleCode = this._createBundleCode.bind(this);
-    var urlSearch = url.parse(req.url).search;
-    var queryParams = parseQueryParams(req);
+  handleBundleRequest(req, res, next) {
+    const createBundleCode = this._createBundleCode.bind(this);
+    const urlSearch = url.parse(req.url).search;
+    const queryParams = parseQueryParams(req);
 
     // Forward URL params to RN packager
-    var reactCodeURL = this.reactCodeURL;
+    let reactCodeURL = this.reactCodeURL;
     if (urlSearch) {
       reactCodeURL += urlSearch;
     }
@@ -221,16 +219,16 @@ Server.prototype = {
       res.writeHead(200);
       res.end(bundleCode);
     }).catch(next);
-  },
+  }
 
-  handleMapRequest: function(req, res, next) {
-    var createBundleMap = this._createBundleMap.bind(this);
-    var urlSearch = url.parse(req.url).search;
-    var queryParams = parseQueryParams(req);
+  handleMapRequest(req, res, next) {
+    const createBundleMap = this._createBundleMap.bind(this);
+    const urlSearch = url.parse(req.url).search;
+    const queryParams = parseQueryParams(req);
 
     // Forward URL params to RN packager
-    var reactCodeURL = this.reactCodeURL;
-    var reactMapURL = this.reactMapURL;
+    let reactCodeURL = this.reactCodeURL;
+    let reactMapURL = this.reactMapURL;
     if (urlSearch) {
       reactCodeURL += urlSearch;
       reactMapURL += urlSearch;
@@ -242,7 +240,7 @@ Server.prototype = {
       appCode: fetch(this.appCodeURL),
       appMap: fetch(this.appMapURL),
     }).then(function(r) {
-      return createBundleMap(r.reactCode, r.reactMap, r.appCode, r.appMap);
+      createBundleMap(r.reactCode, r.reactMap, r.appCode, r.appMap)
     }).then(function(bundleMap) {
       res.writeHead(200);
       res.end(bundleMap);
@@ -250,11 +248,11 @@ Server.prototype = {
       console.error(err);
       next();
     });
-  },
+  }
 
-  handleProcessExit: function() {
+  handleProcessExit() {
     // Clean up temp files
-    var entryDir = this.entryDir;
+    const entryDir = this.entryDir;
     if (fs.existsSync(entryDir)) {
       fs.readdirSync(entryDir).forEach(function(file) {
         fs.unlinkSync(path.join(entryDir, file));
@@ -266,17 +264,17 @@ Server.prototype = {
     if (this.packageServer) {
       this.packageServer.kill();
     }
-  },
+  }
 
-  _createBundleCode: function(reactCode, appCode) {
+  _createBundleCode(reactCode, appCode) {
     reactCode = reactCode.replace(SOURCEMAP_REGEX, '');
     appCode = appCode.replace(SOURCEMAP_REGEX, '');
     return reactCode + appCode + '//# sourceMappingURL=/' + this.entry + '.map';
-  },
+  }
 
-  _createBundleMap: function(reactCode, reactMap, appCode, appMap) {
-    var node = new SourceNode();
-    var map;
+  _createBundleMap(reactCode, reactMap, appCode, appMap) {
+    const node = new SourceNode();
+    let map;
 
     node.add(SourceNode.fromStringWithSourceMap(
       reactCode,
@@ -291,35 +289,35 @@ Server.prototype = {
     map = node.toStringWithSourceMap().map;
 
     return JSON.stringify(map);
-  },
+  }
 
-  _writeEntryFile: function(entryModules) {
-    var source = ENTRY_JS + '\n';
-    var entryFile = path.join(this.entryDir, this.entry + '.js');
+  _writeEntryFile(entryModules) {
+    const source = ENTRY_JS + '\n';
+    const entryFile = path.join(this.entryDir, this.entry + '.js');
     if (!fs.existsSync(this.entryDir)) {
       fs.mkdirSync(this.entryDir);
     }
     fs.writeFileSync(entryFile, source, 'utf-8');
-  },
+  }
 
-  _startPackageServer: function() {
+  _startPackageServer() {
     /**
      * Starting the server is neither fast nor completely reliable we end up
      * hitting its public api over http periodically so we must wait for it to
      * be actually ready.
      */
-    return new Promise(function (accept, reject) {
+    return new Promise(function(accept, reject) {
       // Easier to just shell out to the packager than use the JS API.
       // XXX: Uses the node only invocation so we don't have to deal with bash
       // as well... Fixes issues where server cannot be killed cleanly.
-      var cmd = 'node';
-      var args = [
+      const cmd = 'node';
+      const args = [
         './node_modules/react-native/packager/packager.js',
         '--root', path.resolve(process.cwd(), 'node_modules/react-native'),
         '--root', this.entryDir,
         '--port', this.packagerPort,
       ];
-      var opts = {stdio: 'inherit'};
+      const opts = {stdio: 'inherit'};
       this.packageServer = spawn(cmd, args, opts);
 
       function handleError(err) {
@@ -338,13 +336,13 @@ Server.prototype = {
         accept();
       }.bind(this));
     }.bind(this));
-  },
+  }
 
-  _startWebpackDevServer: function() {
-    var webpackConfig = this.webpackConfig;
-    var webpackURL = 'http://' + this.hostname + ':' + this.webpackPort;
-    var hot = this.hot;
-    var publicPath = hot ? (webpackURL + '/') : null;
+  _startWebpackDevServer() {
+    const webpackConfig = this.webpackConfig;
+    const webpackURL = 'http://' + this.hostname + ':' + this.webpackPort;
+    const hot = this.hot;
+    const publicPath = hot ? (webpackURL + '/') : null;
     return getReactNativeExternals().then(function(reactNativeExternals) {
       return new Promise(function(resolve, reject) {
         // Coerce externals into an array, without clobbering it
@@ -376,7 +374,7 @@ Server.prototype = {
         // require()'d in the RN packager's entry file. This allows for RN
         // modules that aren't part of the main 'react-native' dependency tree
         // to be included in the generated bundle (e.g. AdSupportIOS).
-        var compiler = webpack(webpackConfig);
+        const compiler = webpack(webpackConfig);
         compiler.plugin('done', function(stats) {
           // Write out the RN packager's entry file
           this._writeEntryFile();
@@ -399,8 +397,8 @@ Server.prototype = {
         });
       }.bind(this));
     }.bind(this));
-  },
+  }
 
-};
+}
 
 module.exports = Server;

--- a/lib/getReactNativeExternals.js
+++ b/lib/getReactNativeExternals.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var path = require('path');
+const path = require('path');
 
 /**
  * Extract the React Native module paths
@@ -9,10 +9,10 @@ var path = require('path');
  *                           a webpack 'externals' configuration object
  */
 function getReactNativeExternals() {
-  var reactNativeRoot = path.dirname(require.resolve('react-native/package'));
-  var blacklist = require('react-native/packager/blacklist');
-  var ReactPackager = require('react-native/packager/react-packager');
-  var reactNativePackage = require('react-native/package');
+  const reactNativeRoot = path.dirname(require.resolve('react-native/package'));
+  const blacklist = require('react-native/packager/blacklist');
+  const ReactPackager = require('react-native/packager/react-packager');
+  const reactNativePackage = require('react-native/package');
 
   return ReactPackager.getDependencies({
     assetRoots: [reactNativeRoot],

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "LICENSE",
     "README.md"
   ],
+  "engines": {
+    "node": "^4.0.0",
+    "iojs": ">=2.0.0"
+  },
   "peerDependencies": {
     "react-native": ">=0.11.0",
     "webpack": ">=1.8.4",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   "dependencies": {
     "bluebird": "^2.9.24",
     "connect": "^3.3.5",
-    "source-map": "^0.4.2",
     "nomnom": "^1.8.1",
-    "socket-retry-connect": "0.0.1"
+    "socket-retry-connect": "0.0.1",
+    "source-map": "^0.4.2"
   }
 }


### PR DESCRIPTION
Converted much of the code to use ES6 features supported by Node v4. This means versions of Node < 4 would no longer be supported, though I'm sure how many people use older versions of Node. Thoughts? @amccloud @mjohnston 
