### PR TITLE
Bump to source-map 0.5.x

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -201,8 +201,7 @@ class Server {
   }
 
   _createBundleMap(reactCode, reactMap, appCode, appMap) {
-    let node = new SourceNode();
-    let map;
+    const node = new SourceNode();
 
     node.add(SourceNode.fromStringWithSourceMap(
       reactCode,
@@ -213,10 +212,7 @@ class Server {
       new SourceMapConsumer(appMap)
     ));
 
-    node = node.join('');
-    map = node.toStringWithSourceMap().map;
-
-    return JSON.stringify(map);
+    return node.join('').toStringWithSourceMap().map.toString();
   }
 
   _writeEntryFile() {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "commander": "^2.8.1",
     "express": "^4.13.3",
     "socket-retry-connect": "0.0.1",
-    "source-map": "^0.4.2"
+    "source-map": "^0.5.1"
   },
   "devDependencies": {
     "eslint": "^1.5.1"


### PR DESCRIPTION
(The `return` statement got lost in 3a586c3f64ad093212140de74902c1121452e1c9)

Also, bumps to `source-map` `0.5.x` for what should be a good perf boost: https://github.com/mozilla/source-map/pull/203
