### PR TITLE
Make `bundle` command work on React Native 0.12

### DIFF
--- a/bin/rnws.js
+++ b/bin/rnws.js
@@ -83,10 +83,16 @@ commonOptions(program.command('bundle'))
     'Whether the bundle should skip optimization. [false]',
     false
   )
+  .option(
+    '--platform',
+    'The platform for which to create the bundle. [ios]',
+    'ios'
+  )
   .action(function(options) {
     const opts = options.opts();
     const server = createServer(opts);
     const query = opts.optimize ? {dev: false, minify: true} : {};
+    query.platform = opts.platform || 'ios';
     const bundleUrl = url.format({
       protocol: 'http',
       hostname: 'localhost',


### PR DESCRIPTION
Also accept platform to build the bundle for as an optional parameter and pass it on to the RN packager.
