### PR TITLE
Actually make the --platform switch to bundle command work

### DIFF
--- a/bin/rnws.js
+++ b/bin/rnws.js
@@ -84,7 +84,7 @@ commonOptions(program.command('bundle'))
     false
   )
   .option(
-    '--platform',
+    '--platform [platform]',
     'The platform for which to create the bundle. [ios]',
     'ios'
   )


### PR DESCRIPTION
I never properly tested the `--platform` switch, sorry :(. On top of that, by removing the `|| 'ios'` fallback, https://github.com/mjohnston/react-native-webpack-server/commit/e6b6368b5eff125e5106836c350ae0c042f63f9f broke the `bundle` command again... This fixes it.
