### PR TITLE
Fix a race condition in the `bundle` command

### DIFF
--- a/bin/rnws.js
+++ b/bin/rnws.js
@@ -105,18 +105,18 @@ commonOptions(program.command('bundle'))
     });
     const targetPath = path.resolve(opts.bundlePath);
 
-    server.start();
+    server.start().then(function() {
+      fetch(bundleUrl).then(function(content) {
+        fs.writeFileSync(targetPath, content);
+        server.stop();
 
-    fetch(bundleUrl).then(function(content) {
-      fs.writeFileSync(targetPath, content);
-      server.stop();
-
-      // XXX: Hack something is keeping the process alive but we can still
-      // safely kill here without leaving processes hanging around...
-      process.exit(0);
-    }).catch(function(err) {
-      console.log('Error creating bundle...', err.stack);
-      server.stop();
+        // XXX: Hack something is keeping the process alive but we can still
+        // safely kill here without leaving processes hanging around...
+        process.exit(0);
+      }).catch(function (err) {
+        console.log('Error creating bundle...', err.stack);
+        server.stop();
+      });
     });
   });
 

--- a/bin/rnws.js
+++ b/bin/rnws.js
@@ -106,17 +106,17 @@ commonOptions(program.command('bundle'))
     const targetPath = path.resolve(opts.bundlePath);
 
     server.start().then(function() {
-      fetch(bundleUrl).then(function(content) {
-        fs.writeFileSync(targetPath, content);
-        server.stop();
+      return fetch(bundleUrl);
+    }).then(function(bundleSrc) {
+      fs.writeFileSync(targetPath, bundleSrc);
+      server.stop();
 
-        // XXX: Hack something is keeping the process alive but we can still
-        // safely kill here without leaving processes hanging around...
-        process.exit(0);
-      }).catch(function (err) {
-        console.log('Error creating bundle...', err.stack);
-        server.stop();
-      });
+      // XXX: Hack something is keeping the process alive but we can still
+      // safely kill here without leaving processes hanging around...
+      process.exit(0);
+    }).catch(function (err) {
+      console.log('Error creating bundle...', err.stack);
+      server.stop();
     });
   });
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -125,9 +125,12 @@ class Server {
   start() {
     const hostname = this.hostname;
     const port = this.port;
-    this.httpServer = this.server.listen(port, function() {
-      console.log('Server listening at http://%s:%s', hostname, port);
-    });
+    return new Promise(function (resolve) {
+      this.httpServer = this.server.listen(port, function() {
+        console.log('Server listening at http://%s:%s', hostname, port);
+        this._readyPromise.then(resolve);
+      }.bind(this));
+    }.bind(this));
   }
 
   stop() {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -268,58 +268,65 @@ class Server {
     const hot = this.hot;
     const publicPath = hot ? (webpackURL + '/') : null;
     return getReactNativeExternals().then(function(reactNativeExternals) {
-      return new Promise(function(resolve) {
-        // Coerce externals into an array, without clobbering it
-        webpackConfig.externals = Array.isArray(webpackConfig.externals)
-          ? webpackConfig.externals
-          : [(webpackConfig.externals || {})];
 
-        // Inject react native externals
-        webpackConfig.externals.push(reactNativeExternals);
+      // Coerce externals into an array, without clobbering it
+      webpackConfig.externals = Array.isArray(webpackConfig.externals)
+        ? webpackConfig.externals
+        : [(webpackConfig.externals || {})];
 
-        // Transform static image references
-        webpackConfig.externals.push(staticImageTransform);
+      // Inject react native externals
+      webpackConfig.externals.push(reactNativeExternals);
 
-        // By default webpack uses webpack://[resource-path]?[hash] in the source
-        // map which is handled by its dev server. Use absolute path instead so
-        // React Native's exception manager can load the source maps.
-        webpackConfig.output = webpackConfig.output || {};
-        if (!webpackConfig.output.devtoolModuleFilenameTemplate) {
-          webpackConfig.output.devtoolModuleFilenameTemplate = '[absolute-resource-path]';
-        }
+      // Transform static image references
+      webpackConfig.externals.push(staticImageTransform);
 
-        // Update webpack config for hot mode.
-        if (hot) {
-          makeHotConfig(webpackConfig);
-        }
+      // By default webpack uses webpack://[resource-path]?[hash] in the source
+      // map which is handled by its dev server. Use absolute path instead so
+      // React Native's exception manager can load the source maps.
+      webpackConfig.output = webpackConfig.output || {};
+      if (!webpackConfig.output.devtoolModuleFilenameTemplate) {
+        webpackConfig.output.devtoolModuleFilenameTemplate = '[absolute-resource-path]';
+      }
 
-        // Plug into webpack compilation to extract webpack dependency tree.
-        // Any React Native externals from the application source need to be
-        // require()'d in the RN packager's entry file. This allows for RN
-        // modules that aren't part of the main 'react-native' dependency tree
-        // to be included in the generated bundle (e.g. AdSupportIOS).
-        const compiler = webpack(webpackConfig);
+      // Update webpack config for hot mode.
+      if (hot) {
+        makeHotConfig(webpackConfig);
+      }
+
+      // Plug into webpack compilation to extract webpack dependency tree.
+      // Any React Native externals from the application source need to be
+      // require()'d in the RN packager's entry file. This allows for RN
+      // modules that aren't part of the main 'react-native' dependency tree
+      // to be included in the generated bundle (e.g. AdSupportIOS).
+      const compiler = webpack(webpackConfig);
+
+      const compilerPromise = new Promise(function(resolve) {
         compiler.plugin('done', function() {
           // Write out the RN packager's entry file
           this._writeEntryFile();
-
-          // Conveniently, promises can only be resolved once.
           resolve();
         }.bind(this));
+      }.bind(this));
 
-        this.webpackServer = new WebpackDevServer(compiler, {
-          hot: hot,
-          publicPath: publicPath,
-          headers: {
-            'Access-Control-Allow-Origin': '*',
-          },
-          stats: {colors: true, chunkModules: false},
-        });
+      this.webpackServer = new WebpackDevServer(compiler, {
+        hot: hot,
+        publicPath: publicPath,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+        },
+        stats: {colors: true, chunkModules: false},
+      });
 
+      const serverPromise = new Promise(function(resolve) {
         this.webpackServerHttp = this.webpackServer.listen(this.webpackPort, this.hostname, function() {
           console.log('Webpack dev server listening at ', webpackURL);
+          resolve();
         });
       }.bind(this));
+
+      // Ensure that both the server is up and the compiler's entry
+      // file has been written for the React Native packager.
+      return Promise.all([compilerPromise, serverPromise]);
     }.bind(this));
   }
 


### PR DESCRIPTION
These two changes fix a particular egregious race condition in the `rnws bundle` command on really performance-challenged machines, e.g. whatever steam-powered 19th century hardware Travis uses. The symptom would be `Error: socket hang up` in the part that attempts to `fetch` the bundle from the webpack server, which isn't ready yet. The only explanation that I have for this is that `fetch` is simply called too early sometimes. So the solution is to ensure it's only called when the server(s) is(are) definitely ready.

In this PR, we ensure that
- the RN package server doesn't get started until the webpack compiler not only has written its entry file but the webpack server is actually listening
- `fetch` won't be called until the RN package server is definitely up, which given the previous bullet point implies that the webpack server is listening

(Disclaimer: I'm not entirely certain the first change is 100% necessary, but it helps us a lot in reasoning about when the webpack server has actually started up. It makes the promise chain simpler and I doubt that having it in place will have any impact on startup perf -- I haven't observed any, but I also haven't done any scientific measurements tbh.

If there _are_ any concerns, we could alternatively have the RN package server continue to be launched after the entry file was written, and then make `Server.start()` return a `Promise.all` based on the RN package server and the webpack server. So long as we don't `fetch` before _both_ servers are definitely listening on their ports... I chose not to go down that route because IMHO having `_startWebpackDevServer` resolve the promise when the server is actually listening made more sense to me.)

cc @lightsofapollo 
