### PR TITLE
Fix issues with npm 3

### DIFF
--- a/lib/getReactNativeExternals.js
+++ b/lib/getReactNativeExternals.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const path = require('path');
+const Promise = require('bluebird');
+const fs = Promise.promisifyAll(require('fs'));
 
 /**
  * Extract the React Native module paths
@@ -13,13 +15,35 @@ function getReactNativeExternals() {
   const blacklist = require('react-native/packager/blacklist');
   const ReactPackager = require('react-native/packager/react-packager');
   const reactNativePackage = require('react-native/package');
+  const reactNativeModuleDir = path.join(reactNativeRoot, 'node_modules');
 
-  return ReactPackager.getDependencies({
-    assetRoots: [reactNativeRoot],
-    blacklistRE: blacklist(false /* don't blacklist any platform */),
-    projectRoots: [reactNativeRoot],
-    transformModulePath: require.resolve('react-native/packager/transformer'),
-  }, reactNativePackage.main).then(function(dependencies) {
+  /* Create symlinks for all flattened react-native dependencies */
+  return fs.readdirAsync(reactNativeModuleDir).then(function(modules) {
+    const modulesSet = {};
+    modules.forEach(mod => { modulesSet[mod] = true; });
+
+    return Promise.all(Object.keys(reactNativePackage.dependencies)
+      .filter(dep => !modulesSet[dep])
+      .map(dep => {
+        const src = path.resolve(reactNativeRoot, '..', dep);
+        const dst = path.join(reactNativeModuleDir, dep);
+        return fs.statAsync(src)
+          .catch(() => {})
+          .then(stat => {
+            if (stat && stat.isDirectory()) {
+              return fs.symlinkAsync(src, dst);
+            }
+          });
+      }));
+
+  }).then(function() {
+    return ReactPackager.getDependencies({
+      assetRoots: [reactNativeRoot],
+      blacklistRE: blacklist(false /* don't blacklist any platform */),
+      projectRoots: [reactNativeRoot],
+      transformModulePath: require.resolve('react-native/packager/transformer'),
+    }, reactNativePackage.main);
+  }).then(function(dependencies) {
     return dependencies.filter(function(dependency) {
       return !dependency.isPolyfill();
     });

--- a/lib/getReactNativeExternals.js
+++ b/lib/getReactNativeExternals.js
@@ -31,7 +31,7 @@ function getReactNativeExternals() {
           .catch(() => {})
           .then(stat => {
             if (stat && stat.isDirectory()) {
-              return fs.symlinkAsync(src, dst);
+              return fs.symlinkAsync(path.relative(reactNativeModuleDir, src), dst);
             }
           });
       }));


### PR DESCRIPTION
This is achieved with a workaround that creates symlinks inside `node_modules` for flattened `react-native` dependencies, so that the React Native packager can pick them up.

Fixes #76
