### PR TITLE
Resolve RN dependencies using the project root path

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -270,7 +270,9 @@ class Server {
     const webpackURL = 'http://' + this.hostname + ':' + this.webpackPort;
     const hot = this.hot;
     const publicPath = hot ? (webpackURL + '/') : null;
-    return getReactNativeExternals().then(function(reactNativeExternals) {
+    return getReactNativeExternals({
+      projectRoot: process.cwd(),
+    }).then(function(reactNativeExternals) {
 
       // Coerce externals into an array, without clobbering it
       webpackConfig.externals = Array.isArray(webpackConfig.externals)

--- a/lib/getReactNativeExternals.js
+++ b/lib/getReactNativeExternals.js
@@ -1,25 +1,23 @@
 'use strict';
 
-const path = require('path');
-
 /**
  * Extract the React Native module paths
  *
- * @return {Promise<Object>} A promise which resolves with
- *                           a webpack 'externals' configuration object
+ * @param  {Object}          options             Options
+ * @param  {String}          options.projectRoot The project root path, where `node_modules/` is found
+ * @return {Promise<Object>}                     Resolves with a webpack 'externals' configuration object
  */
-function getReactNativeExternals() {
-  const reactNativeRoot = path.dirname(require.resolve('react-native/package'));
+function getReactNativeExternals(options) {
   const blacklist = require('react-native/packager/blacklist');
   const ReactPackager = require('react-native/packager/react-packager');
-  const reactNativePackage = require('react-native/package');
+  const rnEntryPoint = require.resolve('react-native');
 
   return ReactPackager.getDependencies({
-    assetRoots: [reactNativeRoot],
+    assetRoots: [options.projectRoot],
     blacklistRE: blacklist(false /* don't blacklist any platform */),
-    projectRoots: [reactNativeRoot],
+    projectRoots: [options.projectRoot],
     transformModulePath: require.resolve('react-native/packager/transformer'),
-  }, reactNativePackage.main).then(function(dependencies) {
+  }, rnEntryPoint).then(function(dependencies) {
     return dependencies.filter(function(dependency) {
       return !dependency.isPolyfill();
     });


### PR DESCRIPTION
Fixes #76. A bit less hacky than #106 :stuck_out_tongue_winking_eye: 
Closes #106

Caveat: this still doesn't work in the example projects in this repo:

``` shell
❯ cd Examples/BabelES6
❯ npm install
...
❯ npm start
```

Everything should be error-free up to this point, but opening the app results in this error in the dev tools:

<img width="1025" alt="screenshot 2015-10-22 20 44 02" src="https://cloud.githubusercontent.com/assets/2177366/10681994/ea294e40-78fd-11e5-8f36-769b89907b32.png">

It seems to work though if you move BabelES6 out of the repo, then do an `npm install` and `rm -rf $TMPDIR/react-packager-cache-*`.
