### PR TITLE
Add RN 0.13 support

### DIFF
--- a/Examples/BabelES6/README.md
+++ b/Examples/BabelES6/README.md
@@ -16,6 +16,8 @@ npm run android-setup-port
 react-native run-android
 ```
 
+**NOTE**: In order to be able to run android-setup-port you need to run Android 5.0 since adb reverse was introduced at Android 5.0
+
 To run with hot reload (iOS-only):
 
 ```

--- a/Examples/BabelES6/package.json
+++ b/Examples/BabelES6/package.json
@@ -9,14 +9,13 @@
     "start": "rnws start"
   },
   "dependencies": {
-    "babel": "^5.8.23",
-    "babel-core": "^5.8.25",
+    "babel-core": "^5.8.32",
     "babel-loader": "^5.3.2",
     "babel-plugin-react-transform": "^1.1.1",
-    "react-native": "^0.12.0",
+    "react-native": "^0.13.2",
     "react-native-webpack-server": "file:../..",
     "react-transform-hmr": "^1.0.1",
     "webpack": "^1.12.2",
-    "webpack-dev-server": "^1.12.0"
+    "webpack-dev-server": "^1.12.1"
   }
 }

--- a/Examples/CoffeeScript/package.json
+++ b/Examples/CoffeeScript/package.json
@@ -9,16 +9,16 @@
     "start": "rnws start"
   },
   "dependencies": {
-    "babel-core": "^5.8.25",
+    "babel-core": "^5.8.32",
     "babel-loader": "^5.3.2",
     "babel-plugin-react-transform": "^1.1.1",
     "cjsx-loader": "^2.0.1",
     "coffee-loader": "^0.7.2",
     "coffee-script": "^1.10.0",
-    "react-native": "^0.12.0",
+    "react-native": "^0.13.2",
     "react-native-webpack-server": "file:../..",
     "react-transform-hmr": "^1.0.1",
     "webpack": "^1.12.2",
-    "webpack-dev-server": "^1.12.0"
+    "webpack-dev-server": "^1.12.1"
   }
 }

--- a/lib/getReactNativeExternals.js
+++ b/lib/getReactNativeExternals.js
@@ -1,13 +1,49 @@
 'use strict';
 
+const Promise = require('bluebird');
+
 /**
- * Extract the React Native module paths
+ * Get a webpack 'externals' config for all React Native internal modules.
+ * @param  {Object} options Options
+ * @param  {String}         options.projectRoot The project root path, where `node_modules/` is found
+ * @return {Object}         A webpack 'externals' config object
+ */
+function getReactNativeExternals(options) {
+  return Promise.props({
+    androidModuleNames: getReactNativeDependencyNames({
+      projectRoot: options.projectRoot,
+      platform: 'android',
+    }),
+    iosModuleNames: getReactNativeDependencyNames({
+      projectRoot: options.projectRoot,
+      platform: 'ios',
+    }),
+  }).then(r => {
+    const allReactNativeModules = r.androidModuleNames.concat(r.iosModuleNames);
+    return makeWebpackExternalsConfig(allReactNativeModules);
+  });
+}
+
+/**
+ * Make a webpack 'externals' object from the provided CommonJS module names.
+ * @param  {Array<String>} moduleNames The list of module names
+ * @return {Object}                    A webpack 'externals' config object
+ */
+function makeWebpackExternalsConfig(moduleNames) {
+  return moduleNames.reduce((externals, moduleName) => Object.assign(externals, {
+    [moduleName]: `commonjs ${moduleName}`,
+  }), {});
+}
+
+/**
+ * Extract all non-polyfill dependency names from the React Native packager.
  *
  * @param  {Object}          options             Options
  * @param  {String}          options.projectRoot The project root path, where `node_modules/` is found
+ * @param  {String}          options.platform    The platform for which to get dependencies
  * @return {Promise<Object>}                     Resolves with a webpack 'externals' configuration object
  */
-function getReactNativeExternals(options) {
+function getReactNativeDependencyNames(options) {
   const blacklist = require('react-native/packager/blacklist');
   const ReactPackager = require('react-native/packager/react-packager');
   const rnEntryPoint = require.resolve('react-native');
@@ -17,17 +53,14 @@ function getReactNativeExternals(options) {
     blacklistRE: blacklist(false /* don't blacklist any platform */),
     projectRoots: [options.projectRoot],
     transformModulePath: require.resolve('react-native/packager/transformer'),
-  }, rnEntryPoint).then(dependencies =>
+  }, {
+    entryFile: rnEntryPoint,
+    dev: true,
+    platform: options.platform,
+  }).then(dependencies =>
     dependencies.filter(dependency => !dependency.isPolyfill())
   ).then(dependencies =>
-    Promise.all(dependencies.map(dependency =>
-      dependency.getName()
-    ))
-  ).then(moduleIds =>
-    moduleIds.reduce((externals, moduleId) => {
-      externals[moduleId] = 'commonjs ' + moduleId;
-      return externals;
-    }, {})
+    Promise.all(dependencies.map(dependency => dependency.getName()))
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -36,11 +36,10 @@
     "test": "npm run lint"
   },
   "engines": {
-    "node": "^4.0.0",
-    "iojs": ">=2.0.0"
+    "node": "^4.0.0"
   },
   "peerDependencies": {
-    "react-native": ">=0.11.0",
+    "react-native": ">=0.13.0",
     "webpack": ">=1.8.4",
     "webpack-dev-server": ">=1.8.0"
   },


### PR DESCRIPTION
Added a `platform` value to the `ReactPackager.getDependencies()` call; now it should work with React Native 0.13 :sparkles: 

Thanks to @jhabdas for the tip.

Resolves #90, #111.

Once merged, v0.8.0 will be released :rocket: 
