### PR TITLE
Fixed deprecated reset cache flag

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -267,7 +267,7 @@ class Server {
         '--port', this.packagerPort,
       ].concat(
         this.resetCache ?
-          '--resetCache' :
+          '--reset-cache' :
           []
       );
       const opts = {stdio: 'inherit'};


### PR DESCRIPTION
Gave warning: `Please start using`--reset-cache`instead. We'll deprecate this argument soon.`
