### PR TITLE
bundle: be more resilient against timeouts

### DIFF
--- a/bin/rnws.js
+++ b/bin/rnws.js
@@ -147,6 +147,7 @@ commonOptions(program.command('bundle'))
       .then(doBundle)
       .finally(() => {
         server.stop();
+        process.exit(0);
       });
   });
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -135,6 +135,8 @@ class Server {
           console.log(`Server listening at http://${this.hostname}:${this.port}`);
           resolve();
         });
+        // Disable any kind of automatic timeout behavior on incoming connections.
+        this.httpServer.timeout = 0;
       });
       return Promise.all([listenPromise, readyPromise]);
     });
@@ -357,6 +359,8 @@ class Server {
           console.log('Webpack dev server listening at ', this.webpackBaseURL);
           resolve();
         });
+        // Disable any kind of automatic timeout behavior on incoming connections.
+        this.webpackServer.timeout = 0;
       });
 
       // Ensure that both the server is up and the compiler's entry

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -130,12 +130,13 @@ class Server {
         next(err);
       });
 
-      return new Promise(resolve => {
+      const listenPromise = new Promise(resolve => {
         this.httpServer = this.server.listen(this.port, () => {
           console.log(`Server listening at http://${this.hostname}:${this.port}`);
           resolve();
         });
       });
+      return Promise.all([listenPromise, readyPromise]);
     });
   }
 
@@ -283,7 +284,10 @@ class Server {
 
       this.packageServer.on('error', handleError);
 
-      waitForSocket({ port: this.packagerPort }, err => {
+      // waitForSocket retries the port every 250ms. Let's give the
+      // React Native server up to 30 seconds to come online. watchman
+      // can be slow to ramp up, especially on CI machines.
+      waitForSocket({ port: this.packagerPort, tries: 120 }, err => {
         console.log('react-native packager ready...');
         this.packageServer.removeListener('error', handleError);
         if (err) {

--- a/lib/createBundle.js
+++ b/lib/createBundle.js
@@ -39,7 +39,7 @@ function buildUrl(server, options, type) {
       dev: options.dev,
       minify: options.minify,
     },
-  })
+  });
 }
 
 function download(url, targetPath) {

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -17,7 +17,9 @@ function fetch(uri) {
         }
       });
     };
-    http.request(parts, handler).end();
+    var request = http.request(parts, handler);
+    request.setTimeout(0); // Disable any kind of automatic timeout behavior.
+    request.end();
   });
 }
 


### PR DESCRIPTION
Also don't attempt to fetch the bundle until the RN packager server is actually up. There's little point in trying sooner.
