### PR TITLE
getReactNativeExternals: only pay for what you eat

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -50,8 +50,8 @@ class Server {
    * @param {Number}  port
    * @param {Number}  packagerPort
    * @param {Number}  webpackPort
-   * @param {Boolean} enableAndroid
-   * @param {Boolean} enableIos
+   * @param {Boolean} android       Enable Android support
+   * @param {Boolean} ios           Enable iOS support
    * @param {String}  androidEntry
    * @param {String}  iosEntry
    * @param {Object}  webpackConfig The webpack config to use for webpack-dev-server
@@ -69,6 +69,7 @@ class Server {
       android: options.androidEntry,
       ios: options.iosEntry,
     };
+    this.platforms = options.platforms;
     this.resetCache = !!options.resetCache;
     this.hot = !!options.hot;
     this.webpackConfig = options.webpackConfig;
@@ -306,6 +307,7 @@ class Server {
     const hot = this.hot;
     return getReactNativeExternals({
       projectRoot: process.cwd(),
+      platforms: this.platforms,
     }).then(reactNativeExternals => {
 
       // Coerce externals into an array, without clobbering it

--- a/lib/getReactNativeExternals.js
+++ b/lib/getReactNativeExternals.js
@@ -9,17 +9,13 @@ const Promise = require('bluebird');
  * @return {Object}         A webpack 'externals' config object
  */
 function getReactNativeExternals(options) {
-  return Promise.props({
-    androidModuleNames: getReactNativeDependencyNames({
+  return Promise.all(options.platforms.map(
+    (platform) => getReactNativeDependencyNames({
       projectRoot: options.projectRoot,
-      platform: 'android',
-    }),
-    iosModuleNames: getReactNativeDependencyNames({
-      projectRoot: options.projectRoot,
-      platform: 'ios',
-    }),
-  }).then(r => {
-    const allReactNativeModules = r.androidModuleNames.concat(r.iosModuleNames);
+      platform: platform,
+    })
+  )).then((moduleNamesGroupedByPlatform) => {
+    const allReactNativeModules = Array.prototype.concat.apply([], moduleNamesGroupedByPlatform);
     return makeWebpackExternalsConfig(allReactNativeModules);
   });
 }


### PR DESCRIPTION
We walk the entire `node_modules/` tree twice for each platform. Support starting the server with `--no-<platform>` and ignore said platform when computing externals.
