### PR TITLE
Ability to override RN packager's projectRoots and assetRoots settings

### DIFF
--- a/bin/rnws.js
+++ b/bin/rnws.js
@@ -7,7 +7,7 @@ const packageJson = require('../package.json');
 const createBundle = require('../lib/createBundle');
 const Server = require('../lib/Server');
 
-function normalizePlatforms(options) {
+function normalizeOptions(options) {
   options.platforms = [];
   if (options.android) {
     options.platforms.push('android');
@@ -15,6 +15,16 @@ function normalizePlatforms(options) {
   if (options.ios) {
     options.platforms.push('ios');
   }
+
+  if (options.projectRoots) {
+    options.projectRoots = options.projectRoots.split(',')
+      .map(dir => path.resolve(process.cwd(), dir));
+  }
+  if (options.assetRoots) {
+    options.assetRoots = options.assetRoots.split(',')
+      .map(dir => path.resolve(process.cwd(), dir));
+  }
+
   return options;
 }
 
@@ -89,6 +99,16 @@ function commonOptions(program) {
       'index.ios'
     )
     .option(
+      '--projectRoots [projectRoots]',
+      'List of comma-separated paths for the react-native packager to consider as project root directories',
+      null
+    )
+    .option(
+      '--assetRoots [assetRoots]',
+      'List of comma-separated paths for the react-native packager to consider as asset root directories',
+      null
+    )
+    .option(
       '-r, --resetCache',
       'Remove cached react-native packager files [false]',
       false
@@ -99,7 +119,7 @@ commonOptions(program.command('start'))
   .description('Start the webpack server.')
   .option('-r, --hot', 'Enable hot module replacement. [false]', false)
   .action(function(options) {
-    const opts = normalizePlatforms(options.opts());
+    const opts = normalizeOptions(options.opts());
     const server = createServer(opts);
     server.start();
   });
@@ -127,7 +147,7 @@ commonOptions(program.command('bundle'))
     false
   )
   .action(function(options) {
-    const opts = normalizePlatforms(options.opts());
+    const opts = normalizeOptions(options.opts());
     const server = createServer(opts);
     const bundlePaths = {
       android: opts.androidBundlePath,

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -70,6 +70,8 @@ class Server {
       ios: options.iosEntry,
     };
     this.platforms = options.platforms;
+    this.projectRoots = options.projectRoots;
+    this.assetRoots = options.assetRoots;
     this.resetCache = !!options.resetCache;
     this.hot = !!options.hot;
     this.webpackConfig = options.webpackConfig;
@@ -274,6 +276,10 @@ class Server {
         '--root', this.entryDir,
         '--port', this.packagerPort,
       ]).concat(
+        this.projectRoots ? ['--projectRoots', this.projectRoots.join(',')] : []
+      ).concat(
+        this.assetRoots ? ['--assetRoots', this.assetRoots.join(',')] : []
+      ).concat(
         this.resetCache
           ? '--reset-cache'
           : []
@@ -306,7 +312,8 @@ class Server {
     const webpackConfig = this.webpackConfig;
     const hot = this.hot;
     return getReactNativeExternals({
-      projectRoot: process.cwd(),
+      projectRoots: this.projectRoots,
+      assetRoots: this.assetRoots,
       platforms: this.platforms,
     }).then(reactNativeExternals => {
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -280,9 +280,7 @@ class Server {
       ).concat(
         this.assetRoots ? ['--assetRoots', this.assetRoots.join(',')] : []
       ).concat(
-        this.resetCache
-          ? '--reset-cache'
-          : []
+        this.resetCache ? '--reset-cache' : []
       );
       const opts = {stdio: 'inherit'};
       this.packageServer = spawn(cmd, args, opts);

--- a/lib/getReactNativeExternals.js
+++ b/lib/getReactNativeExternals.js
@@ -11,7 +11,8 @@ const Promise = require('bluebird');
 function getReactNativeExternals(options) {
   return Promise.all(options.platforms.map(
     (platform) => getReactNativeDependencyNames({
-      projectRoot: options.projectRoot,
+      projectRoots: options.projectRoots || [process.cwd()],
+      assetRoots: options.assetRoots || [process.cwd()],
       platform: platform,
     })
   )).then((moduleNamesGroupedByPlatform) => {
@@ -45,9 +46,9 @@ function getReactNativeDependencyNames(options) {
   const rnEntryPoint = require.resolve('react-native');
 
   return ReactPackager.getDependencies({
-    assetRoots: [options.projectRoot],
     blacklistRE: blacklist(false /* don't blacklist any platform */),
-    projectRoots: [options.projectRoot],
+    projectRoots: options.projectRoots,
+    assetRoots: options.assetRoots,
     transformModulePath: require.resolve('react-native/packager/transformer'),
   }, {
     entryFile: rnEntryPoint,


### PR DESCRIPTION
By overriding these options, the rnws consumer can more accurately restrict the directories that the RN packager is allowed to walk, which can yield significant gains in start-up speed.
