### PR TITLE
Make exposing all of React Native's internal Haste modules as webpack externals optional

### DIFF
--- a/bin/rnws.js
+++ b/bin/rnws.js
@@ -112,6 +112,11 @@ function commonOptions(program) {
       '-r, --resetCache',
       'Remove cached react-native packager files [false]',
       false
+    )
+    .option(
+      '--hasteExternals',
+      'Allow direct import of React Native\'s internal Haste modules [false]',
+      false
     );
 }
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -17,15 +17,24 @@ const getReactNativeExternals = require('./getReactNativeExternals');
 const waitForSocket = require('socket-retry-connect').waitForSocket;
 const fetch = require('./fetch');
 
-const ENTRY_JS = 'global.React = require("react-native");';
+const ENTRY_JS = 'global.__reactNative = require("react-native");';
 const SOURCEMAP_REGEX = /\/\/[#@] sourceMappingURL=([^\s'"]*)/;
+
+function reactNativeTransform(context, request, callback) {
+  if (request === 'react-native') {
+    callback(null, '__reactNative');
+    return;
+  }
+  callback();
+}
 
 function staticImageTransform(context, request, callback) {
   if (/^image!/.test(request)) {
-    return callback(null, JSON.stringify({
+    callback(null, JSON.stringify({
       uri: request.replace('image!', ''),
       isStatic: true,
     }));
+    return;
   }
   callback();
 }
@@ -56,6 +65,7 @@ class Server {
    * @param {String}  iosEntry
    * @param {Object}  webpackConfig The webpack config to use for webpack-dev-server
    * @param {Boolean} hot           Enable hot module replacement
+   * @param {Boolean} hasteExternals Enable direct import of Haste modules via webpack externals
    *
    * @constructor
    * @param {Object} options
@@ -75,6 +85,7 @@ class Server {
     this.resetCache = !!options.resetCache;
     this.hot = !!options.hot;
     this.webpackConfig = options.webpackConfig;
+    this.hasteExternals = options.hasteExternals;
 
     // Check for local react-native.
     try {
@@ -309,11 +320,16 @@ class Server {
   _startWebpackDevServer() {
     const webpackConfig = this.webpackConfig;
     const hot = this.hot;
-    return getReactNativeExternals({
-      projectRoots: this.projectRoots,
-      assetRoots: this.assetRoots,
-      platforms: this.platforms,
-    }).then(reactNativeExternals => {
+
+    let initPromise = Promise.resolve(null);
+    if (this.hasteExternals) {
+      initPromise = getReactNativeExternals({
+        projectRoots: this.projectRoots,
+        assetRoots: this.assetRoots,
+        platforms: this.platforms,
+      });
+    }
+    return initPromise.then(reactNativeExternals => {
       let configs = Array.isArray(webpackConfig) ? webpackConfig : [webpackConfig];
       configs.forEach(function (config) {
         // Coerce externals into an array, without clobbering it
@@ -322,7 +338,11 @@ class Server {
           : [(config.externals || {})];
 
         // Inject react native externals
-        config.externals.push(reactNativeExternals);
+        if (reactNativeExternals) {
+          config.externals.push(reactNativeExternals);
+        } else {
+          config.externals.push(reactNativeTransform);
+        }
 
         // Transform static image references
         config.externals.push(staticImageTransform);


### PR DESCRIPTION
This avoids traversing the React Native module tree at startup. Since directly importing a Haste module isn't supported by the React Native packager, most apps will probably not need this feature anyway, which is why we turn it off by default and only make those who need it incur the hit in startup time.
