### PR TITLE
Update BabelES6 example to React Native 0.23

### DIFF
--- a/Examples/BabelES6/android/build.gradle
+++ b/Examples/BabelES6/android/build.gradle
@@ -16,5 +16,9 @@ allprojects {
     repositories {
         mavenLocal()
         jcenter()
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url "$projectDir/../../node_modules/react-native/android"
+        }
     }
 }

--- a/Examples/BabelES6/package.json
+++ b/Examples/BabelES6/package.json
@@ -9,12 +9,12 @@
     "start": "rnws start"
   },
   "dependencies": {
-    "babel-core": "^6.3.13",
-    "babel-preset-es2015": "^6.3.13",
-    "babel-preset-react": "^6.3.13",
-    "babel-preset-stage-0": "^6.3.13",
+    "babel-core": "^6.6.4",
+    "babel-preset-es2015": "^6.5.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-0": "^6.5.0",
     "babel-loader": "^6.2.0",
-    "react-native": "^0.17.0",
+    "react-native": "^0.23.0",
     "react-native-webpack-server": "file:../..",
     "react-transform-hmr": "^1.0.1",
     "webpack": "^1.12.2",

--- a/Examples/BabelES6/webpack.config.js
+++ b/Examples/BabelES6/webpack.config.js
@@ -25,7 +25,6 @@ var config = {
       test: /\.js$/,
       include: [
         path.resolve(__dirname, 'src'),
-        path.resolve(__dirname, 'node_modules/react-native/Libraries/react-native'),
         path.resolve(__dirname, 'node_modules/react-native-navbar'),
       ],
       loader: 'babel',

--- a/bin/rnws.js
+++ b/bin/rnws.js
@@ -115,7 +115,12 @@ function commonOptions(program) {
     )
     .option(
       '--hasteExternals',
-      'Allow direct import of React Native\'s internal Haste modules [false]',
+      // React Native 0.23 rewrites `require('HasteModule')` calls to
+      // `require(42)` where 42 is an internal module id. That breaks
+      // treating Haste modules simply as commonjs modules and leaving
+      // the `require()` call in the source. So for now this feature
+      // only works with React Native <0.23.
+      'Allow direct import of React Native\'s (<0.23) internal Haste modules [false]',
       false
     );
 }


### PR DESCRIPTION
Also clarify that `--hasteExternals` only works for React Native <0.23.
