### PR TITLE
Let the React Native packager provide the 'react' module as well

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -17,10 +17,17 @@ const getReactNativeExternals = require('./getReactNativeExternals');
 const waitForSocket = require('socket-retry-connect').waitForSocket;
 const fetch = require('./fetch');
 
-const ENTRY_JS = 'global.__reactNative = require("react-native");';
+const ENTRY_JS = '\
+global.__react = require("react");\
+global.__reactNative = require("react-native");\
+';
 const SOURCEMAP_REGEX = /\/\/[#@] sourceMappingURL=([^\s'"]*)/;
 
-function reactNativeTransform(context, request, callback) {
+function reactImportTransform(context, request, callback) {
+  if (request === 'react') {
+    callback(null, '__react');
+    return;
+  }
   if (request === 'react-native') {
     callback(null, '__reactNative');
     return;
@@ -341,7 +348,7 @@ class Server {
         if (reactNativeExternals) {
           config.externals.push(reactNativeExternals);
         } else {
-          config.externals.push(reactNativeTransform);
+          config.externals.push(reactImportTransform);
         }
 
         // Transform static image references


### PR DESCRIPTION
In recent React Native versions, consumers are encouraged to import pure React APIs straight from the `'react'` module. React Native obviously already includes the `'react'` module in its bundle, so there's no reason to have webpack package it again. So we just export it here.
