### PR TITLE
Insert rnws entry files first into the React Native packager's search path

### DIFF
--- a/bin/rnws.js
+++ b/bin/rnws.js
@@ -20,6 +20,10 @@ function normalizeOptions(options) {
     options.projectRoots = options.projectRoots.split(',')
       .map(dir => path.resolve(process.cwd(), dir));
   }
+  if (options.root) {
+    options.root = options.root.split(',')
+      .map(dir => path.resolve(process.cwd(), dir));
+  }
   if (options.assetRoots) {
     options.assetRoots = options.assetRoots.split(',')
       .map(dir => path.resolve(process.cwd(), dir));
@@ -101,6 +105,11 @@ function commonOptions(program) {
     .option(
       '--projectRoots [projectRoots]',
       'List of comma-separated paths for the react-native packager to consider as project root directories',
+      null
+    )
+    .option(
+      '--root [root]',
+      'List of comma-separated paths for the react-native packager to consider as additional directories. If provided, these paths must include react-native and its dependencies.',
       null
     )
     .option(

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -88,6 +88,7 @@ class Server {
     };
     this.platforms = options.platforms;
     this.projectRoots = options.projectRoots;
+    this.additionalRoots = options.root;
     this.assetRoots = options.assetRoots;
     this.resetCache = !!options.resetCache;
     this.hot = !!options.hot;
@@ -290,12 +291,16 @@ class Server {
         semver.lt(reactNativeVersion, '0.14.0')
           ? ['./node_modules/react-native/packager/packager.js']
           : ['./node_modules/react-native/local-cli/cli.js', 'start'];
+
+      const projectRoots = this.projectRoots || [];
+      projectRoots.unshift(this.entryDir);
+      const additionalRoots = this.additionalRoots || [process.cwd()];
+
       const args = script.concat([
-        '--root', this.entryDir,
         '--port', this.packagerPort,
+        '--projectRoots', projectRoots.join(','),
+        '--root', additionalRoots.join(','),
       ]).concat(
-        this.projectRoots ? ['--projectRoots', this.projectRoots.join(',')] : []
-      ).concat(
         this.assetRoots ? ['--assetRoots', this.assetRoots.join(',')] : []
       ).concat(
         this.resetCache ? '--reset-cache' : []


### PR DESCRIPTION
The directory with rnws entry files becomes the React Native packager's `projectRoot` whereas the app directory becomes a regular `root`. The `--root` arg can be used to replace that default with a more narrowed down list.
